### PR TITLE
Add aznbsetup.sh so default python version is 3

### DIFF
--- a/aznbsetup.sh
+++ b/aznbsetup.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "alias python=python3" > /home/nbuser/.bash_aliases


### PR DESCRIPTION
To verify: relaunch AzureNotebook instance, open terminal and run `python --version`